### PR TITLE
pyproject: use poetry-core instead of poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,5 +113,5 @@ addopts = "--ignore=quickstart* --doctest-modules"
 
 # build-system -----------------------------------------------------------------
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
The PEP517 backend for poetry has been extracted in a separate package as per https://pypi.org/project/poetry-core/